### PR TITLE
Update embedding url in input.ts

### DIFF
--- a/input.ts
+++ b/input.ts
@@ -20,7 +20,7 @@ import trie from 'trie-prefix-tree';
 import * as utils from './visualization/utils';
 
 const EMBEDDINGS_DIR =
-    'https://storage.googleapis.com/barbican-waterfall-of-meaning/'
+    'https://storage.googleapis.com/waterfall-of-meaning/'
 const EMBEDDINGS_WORDS_URL = EMBEDDINGS_DIR + 'embedding-words.json';
 const EMBEDDINGS_VALUES_URL = EMBEDDINGS_DIR + 'embedding-values.bin';
 const BARBICAN_DATABASE_NAME = 'barbican-database';


### PR DESCRIPTION
I think this is set to old storage location which causes it to load old embeddings for the input, so city names and all other new words do not appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/waterfall-of-meaning/17)
<!-- Reviewable:end -->
